### PR TITLE
Feature rlp 33

### DIFF
--- a/src/components/api/APIConstants.ts
+++ b/src/components/api/APIConstants.ts
@@ -1,0 +1,25 @@
+import { EndpointsEnum } from "../types/types";
+
+const BACKEND_ADDRESS = `https://rslangbackend.herokuapp.com`;
+const WORDS_ENDPOINT = `${BACKEND_ADDRESS}/${EndpointsEnum.words}`;
+const USERS_ENDPOINT = `${BACKEND_ADDRESS}/${EndpointsEnum.users}`;
+const SIGNIN_ENDPOINT = `${BACKEND_ADDRESS}/${EndpointsEnum.signin}`;
+
+const HEADERS_FOR_REQUESTS_WITH_AUTH = {
+  Accept: "application/json",
+  Authorization: `Bearer ${localStorage.getItem("token")}`,
+  "Content-type": "application/json; charset=utf-8",
+};
+
+const HEADERS_FOR_REQUESTS_WITHOUT_AUTH = {
+  Accept: "application/json",
+  "Content-type": "application/json",
+};
+
+export default {
+  wordsEndpoint: WORDS_ENDPOINT,
+  usersEndpoint: USERS_ENDPOINT,
+  signinEndpoint: SIGNIN_ENDPOINT,
+  HEADERS_FOR_REQUESTS_WITH_AUTH,
+  HEADERS_FOR_REQUESTS_WITHOUT_AUTH,
+};

--- a/src/components/api/SigninEndpoint.ts
+++ b/src/components/api/SigninEndpoint.ts
@@ -1,0 +1,47 @@
+import { ILogin, UserLoginInformationType } from "../types/types";
+import APIConstants from "./APIConstants";
+
+const logIn = async (
+  email: string,
+  password: string
+): Promise<ILogin | UserLoginInformationType> => {
+  const requestBody: UserLoginInformationType = {
+    email,
+    password,
+  };
+  const data: ILogin | UserLoginInformationType = await fetch(
+    `${APIConstants.signinEndpoint}`,
+    {
+      method: "POST",
+      body: JSON.stringify(requestBody),
+      headers: APIConstants.HEADERS_FOR_REQUESTS_WITHOUT_AUTH,
+    }
+  )
+    .then((response: Response) => {
+      if (response.status === 200) {
+        const json: Promise<ILogin> = response.json();
+        json.then((resData: ILogin) => {
+          Object.entries(resData).forEach((param: Array<string>): void => {
+            if (param[0] !== "message") {
+              if (!localStorage.getItem(param[0])) {
+                localStorage.setItem(param[0], param[1]);
+              }
+            }
+          });
+        });
+      }
+      return {
+        email: "Please check your email",
+        password: "Please check your password",
+      };
+    })
+    .catch((err) => err);
+  return data;
+};
+
+const logOut = (): void => {
+  localStorage.clear();
+  window.location.reload();
+};
+
+export { logIn, logOut };

--- a/src/components/api/UsersEndpoint.ts
+++ b/src/components/api/UsersEndpoint.ts
@@ -1,0 +1,117 @@
+import {
+  DBErrorsType,
+  UserServerError422Type,
+  IUser,
+  IUserEmailOrPasswordIncorrect,
+  IUserExistsError,
+  UserLoginInformationType,
+  ILogin,
+} from "../types/types";
+import APIConstants from "./APIConstants";
+
+export async function getUser(userId: string): Promise<IUser | void> {
+  const data: IUser | void = await fetch(
+    `${APIConstants.usersEndpoint}/${userId}`,
+    {
+      method: "GET",
+      headers: APIConstants.HEADERS_FOR_REQUESTS_WITH_AUTH,
+    }
+  )
+    .then((response: Response) => response.json())
+    .then((respData: IUser) => respData)
+    .catch((err: Error) => console.log(err));
+  return data;
+}
+
+export async function createUser(
+  name: string,
+  email: string,
+  password: string
+): Promise<IUser | IUserExistsError | IUserEmailOrPasswordIncorrect> {
+  try {
+    const requestBody: IUser = {
+      name,
+      email,
+      password,
+    };
+    const response: Response = await fetch(`${APIConstants.usersEndpoint}`, {
+      method: "POST",
+      headers: APIConstants.HEADERS_FOR_REQUESTS_WITHOUT_AUTH,
+      body: JSON.stringify(requestBody),
+    });
+    if (response.status === 417) {
+      return { create_user_form: "User with this email exists" };
+    }
+    const data: IUser = await response.json();
+    return data;
+  } catch (err) {
+    const formErrors: IUserEmailOrPasswordIncorrect = {};
+    if (typeof err === "object") {
+      if (
+        (err as UserServerError422Type).error &&
+        typeof (err as UserServerError422Type).error === "object" &&
+        (err as UserServerError422Type).error.errors
+      ) {
+        (err as UserServerError422Type).error.errors.forEach(
+          (e: DBErrorsType) => {
+            console.log(e);
+            if (e.path[0] === "email") {
+              formErrors.email = e.message;
+            } else if (e.path[0] === "password") {
+              formErrors.password = e.message;
+            }
+          }
+        );
+      }
+    }
+    return formErrors;
+  }
+}
+
+export async function updateUser(
+  userId: string,
+  password: string,
+  email: string
+): Promise<IUser | unknown> {
+  const requestBody: UserLoginInformationType = {
+    email,
+    password,
+  };
+  try {
+    const response: Response = await fetch(
+      `${APIConstants.usersEndpoint}/${userId}`,
+      {
+        headers: APIConstants.HEADERS_FOR_REQUESTS_WITH_AUTH,
+        body: JSON.stringify(requestBody),
+      }
+    );
+    const data: IUser = await response.json();
+    return data;
+  } catch (error) {
+    console.log(error);
+    return error;
+  }
+}
+
+export async function getNewTokens(userId: string): Promise<void> {
+  const headers = {
+    Authorization: `Bearer ${localStorage.getItem("refreshToken") || ""}`,
+    Accept: "application/json",
+    "Content-type": "application/json; charset=utf-8",
+  };
+  try {
+    const response: Response = await fetch(
+      `${APIConstants.usersEndpoint}/${userId}/tokens`,
+      {
+        headers,
+      }
+    );
+    const data: ILogin = await response.json();
+    localStorage.setItem("token", data.token);
+    localStorage.setItem("refreshToken", data.refreshToken);
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+export default { getUser, createUser, updateUser, getNewTokens };

--- a/src/components/api/WordsEndpoint.ts
+++ b/src/components/api/WordsEndpoint.ts
@@ -1,0 +1,27 @@
+import APIConstants from "./APIConstants";
+import { IWord } from "../types/types";
+
+const getWords = async (group: string, page: string): Promise<Array<IWord>> => {
+  const data: Array<IWord> = await fetch(
+    `${APIConstants.wordsEndpoint}?group=${group}&page=${page}`,
+    {
+      method: "GET",
+      headers: APIConstants.HEADERS_FOR_REQUESTS_WITHOUT_AUTH,
+    }
+  )
+    .then((response: Response) => response.json())
+    .then((respData: Array<IWord>) => respData);
+  return data;
+};
+
+const getWord = async (wordId: string): Promise<IWord> => {
+  const data: IWord = await fetch(`${APIConstants.wordsEndpoint}/${wordId}`, {
+    method: "GET",
+    headers: APIConstants.HEADERS_FOR_REQUESTS_WITHOUT_AUTH,
+  })
+    .then((response: Response) => response.json())
+    .then((respData: IWord) => respData);
+  return data;
+};
+
+export { getWord, getWords };

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -8,6 +8,7 @@ enum EndpointsEnum {
   signin = "signin",
 }
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 interface ILogin {
   message?: string;
@@ -17,12 +18,23 @@ interface ILogin {
   name?: string;
 }
 =======
+=======
+>>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 interface ILogin {
   message: string;
   token: string;
   refreshToken: string;
   userId: string;
   name: string;
+=======
+
+interface ILogin {
+  message?: string;
+  token: string;
+  refreshToken: string;
+  userId?: string;
+  name?: string;
+>>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
 }
 
 >>>>>>> ba231a0 (feat: basic types, which API returns, were added)
@@ -37,6 +49,7 @@ interface IStatistics {
 }
 
 interface IUser {
+<<<<<<< HEAD
 <<<<<<< HEAD
   id?: string;
   name: string;
@@ -56,6 +69,26 @@ interface IUserEmailOrPasswordIncorrect {
   name: string;
   email: string;
 >>>>>>> ba231a0 (feat: basic types, which API returns, were added)
+=======
+  id: string;
+  name: string;
+  email: string;
+=======
+  id?: string;
+  name: string;
+  email: string;
+  password?: string;
+}
+
+interface IUserExistsError {
+  create_user_form: string;
+}
+
+interface IUserEmailOrPasswordIncorrect {
+  email?: string;
+  password?: string;
+>>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
+>>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 }
 
 interface IUserWord {
@@ -85,6 +118,10 @@ type UserLoginInformationType = {
 };
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+=======
+>>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 type DBErrorsType = {
   path: string[];
   message: string;
@@ -97,14 +134,19 @@ type UserServerError422Type = {
   };
 };
 
+<<<<<<< HEAD
 =======
 >>>>>>> ba231a0 (feat: basic types, which API returns, were added)
+=======
+>>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
+>>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 export {
   EndpointsEnum,
   ILogin,
   ISettings,
   IStatistics,
   IUser,
+<<<<<<< HEAD
 <<<<<<< HEAD
   IUserExistsError,
   IUserEmailOrPasswordIncorrect,
@@ -118,4 +160,18 @@ export {
   IWord,
   UserLoginInformationType,
 >>>>>>> ba231a0 (feat: basic types, which API returns, were added)
+=======
+  IUserWord,
+  IWord,
+  UserLoginInformationType,
+=======
+  IUserExistsError,
+  IUserEmailOrPasswordIncorrect,
+  IUserWord,
+  IWord,
+  DBErrorsType,
+  UserLoginInformationType,
+  UserServerError422Type,
+>>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
+>>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 };

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -1,0 +1,96 @@
+enum EndpointsEnum {
+  words = "words",
+  users = "users",
+  tokens = "tokens",
+  aggregatedWords = "aggregatedWords",
+  statistics = "statistics",
+  settings = "settings",
+  signin = "signin",
+}
+
+interface ILogin {
+  message?: string;
+  token: string;
+  refreshToken: string;
+  userId?: string;
+  name?: string;
+}
+
+interface ISettings {
+  wordsPerDay: number;
+  optional: undefined;
+}
+
+interface IStatistics {
+  learnedWords: number;
+  optional: undefined;
+}
+
+interface IUser {
+  id?: string;
+  name: string;
+  email: string;
+  password?: string;
+}
+
+interface IUserExistsError {
+  create_user_form: string;
+}
+
+interface IUserEmailOrPasswordIncorrect {
+  email?: string;
+  password?: string;
+}
+
+interface IUserWord {
+  difficulty: string;
+  optional: undefined;
+}
+
+interface IWord {
+  id: string;
+  group: number;
+  page: number;
+  image: string;
+  audio: string;
+  audioMeaning: string;
+  audioExample: string;
+  textMeaning: string;
+  textExample: string;
+  transcription: string;
+  wordTranslate: string;
+  textMeaningTranslate: string;
+  textExampleTranslate: string;
+}
+
+type UserLoginInformationType = {
+  email: string;
+  password: string;
+};
+
+type DBErrorsType = {
+  path: string[];
+  message: string;
+};
+
+type UserServerError422Type = {
+  error: {
+    status: string;
+    errors: DBErrorsType[];
+  };
+};
+
+export {
+  EndpointsEnum,
+  ILogin,
+  ISettings,
+  IStatistics,
+  IUser,
+  IUserExistsError,
+  IUserEmailOrPasswordIncorrect,
+  IUserWord,
+  IWord,
+  DBErrorsType,
+  UserLoginInformationType,
+  UserServerError422Type,
+};

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -15,7 +15,6 @@ interface ILogin {
   userId?: string;
   name?: string;
 }
-
 interface ISettings {
   wordsPerDay: number;
   optional: undefined;

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -7,8 +7,6 @@ enum EndpointsEnum {
   settings = "settings",
   signin = "signin",
 }
-<<<<<<< HEAD
-<<<<<<< HEAD
 
 interface ILogin {
   message?: string;
@@ -17,27 +15,7 @@ interface ILogin {
   userId?: string;
   name?: string;
 }
-=======
-=======
->>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
-interface ILogin {
-  message: string;
-  token: string;
-  refreshToken: string;
-  userId: string;
-  name: string;
-=======
 
-interface ILogin {
-  message?: string;
-  token: string;
-  refreshToken: string;
-  userId?: string;
-  name?: string;
->>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
-}
-
->>>>>>> ba231a0 (feat: basic types, which API returns, were added)
 interface ISettings {
   wordsPerDay: number;
   optional: undefined;
@@ -49,8 +27,6 @@ interface IStatistics {
 }
 
 interface IUser {
-<<<<<<< HEAD
-<<<<<<< HEAD
   id?: string;
   name: string;
   email: string;
@@ -64,31 +40,6 @@ interface IUserExistsError {
 interface IUserEmailOrPasswordIncorrect {
   email?: string;
   password?: string;
-=======
-  id: string;
-  name: string;
-  email: string;
->>>>>>> ba231a0 (feat: basic types, which API returns, were added)
-=======
-  id: string;
-  name: string;
-  email: string;
-=======
-  id?: string;
-  name: string;
-  email: string;
-  password?: string;
-}
-
-interface IUserExistsError {
-  create_user_form: string;
-}
-
-interface IUserEmailOrPasswordIncorrect {
-  email?: string;
-  password?: string;
->>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
->>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 }
 
 interface IUserWord {
@@ -117,11 +68,6 @@ type UserLoginInformationType = {
   password: string;
 };
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 type DBErrorsType = {
   path: string[];
   message: string;
@@ -134,20 +80,12 @@ type UserServerError422Type = {
   };
 };
 
-<<<<<<< HEAD
-=======
->>>>>>> ba231a0 (feat: basic types, which API returns, were added)
-=======
->>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
->>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 export {
   EndpointsEnum,
   ILogin,
   ISettings,
   IStatistics,
   IUser,
-<<<<<<< HEAD
-<<<<<<< HEAD
   IUserExistsError,
   IUserEmailOrPasswordIncorrect,
   IUserWord,
@@ -155,23 +93,4 @@ export {
   DBErrorsType,
   UserLoginInformationType,
   UserServerError422Type,
-=======
-  IUserWord,
-  IWord,
-  UserLoginInformationType,
->>>>>>> ba231a0 (feat: basic types, which API returns, were added)
-=======
-  IUserWord,
-  IWord,
-  UserLoginInformationType,
-=======
-  IUserExistsError,
-  IUserEmailOrPasswordIncorrect,
-  IUserWord,
-  IWord,
-  DBErrorsType,
-  UserLoginInformationType,
-  UserServerError422Type,
->>>>>>> 3533a83 (feat: basic API methods for User, Word, Login endpoints were added)
->>>>>>> 6427683 (feat: basic API methods for User, Word, Login endpoints were added)
 };

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -7,6 +7,7 @@ enum EndpointsEnum {
   settings = "settings",
   signin = "signin",
 }
+<<<<<<< HEAD
 
 interface ILogin {
   message?: string;
@@ -15,6 +16,16 @@ interface ILogin {
   userId?: string;
   name?: string;
 }
+=======
+interface ILogin {
+  message: string;
+  token: string;
+  refreshToken: string;
+  userId: string;
+  name: string;
+}
+
+>>>>>>> ba231a0 (feat: basic types, which API returns, were added)
 interface ISettings {
   wordsPerDay: number;
   optional: undefined;
@@ -26,6 +37,7 @@ interface IStatistics {
 }
 
 interface IUser {
+<<<<<<< HEAD
   id?: string;
   name: string;
   email: string;
@@ -39,6 +51,11 @@ interface IUserExistsError {
 interface IUserEmailOrPasswordIncorrect {
   email?: string;
   password?: string;
+=======
+  id: string;
+  name: string;
+  email: string;
+>>>>>>> ba231a0 (feat: basic types, which API returns, were added)
 }
 
 interface IUserWord {
@@ -67,6 +84,7 @@ type UserLoginInformationType = {
   password: string;
 };
 
+<<<<<<< HEAD
 type DBErrorsType = {
   path: string[];
   message: string;
@@ -79,12 +97,15 @@ type UserServerError422Type = {
   };
 };
 
+=======
+>>>>>>> ba231a0 (feat: basic types, which API returns, were added)
 export {
   EndpointsEnum,
   ILogin,
   ISettings,
   IStatistics,
   IUser,
+<<<<<<< HEAD
   IUserExistsError,
   IUserEmailOrPasswordIncorrect,
   IUserWord,
@@ -92,4 +113,9 @@ export {
   DBErrorsType,
   UserLoginInformationType,
   UserServerError422Type,
+=======
+  IUserWord,
+  IWord,
+  UserLoginInformationType,
+>>>>>>> ba231a0 (feat: basic types, which API returns, were added)
 };


### PR DESCRIPTION
Добавлены базовые методы api для эндпойнтов User, Word, SignIn:

Endpoint User:
GetUser - получает данные о пользователе по userId.
createUser - создает пользователя, входные параметры: name, email, password.
updateUser - обновляет емейл, пароль пользователя, входные параметры: userId, password, email
getNewTokens - получает новые токены по userId.

Endpoint signIn:
logIn - метод получает по email и password токены для пользователя.
logOut - очищает localStorage с последующей перезагрузкой страницы.

Endpoint Words:
getWords - получает данные о словах, входные параметры group и page.
getWord - получает данные о слове, входной параметр wordId